### PR TITLE
app.yaml :locations:scripts flag is bool, not string

### DIFF
--- a/src/main/resources/schema/app.schema.json
+++ b/src/main/resources/schema/app.schema.json
@@ -106,7 +106,7 @@
                 "description": "Whether to allow serving files which don’t match a rule."
               },
               "scripts": {
-                "type": "string",
+                "type": "boolean",
                 "description": "Whether to allow loading scripts in that location. Meaningful only on PHP containers."
               },
               "headers": {


### PR DESCRIPTION
per https://docs.platform.sh/create-apps/app-reference.html#locations , the `scripts` flag is boolean.

```
web:
    locations:
        '/sites/default/files':
            scripts: false
```

was incorrectly being marked as a warning when I tried out the yaml validation.